### PR TITLE
Macos should not be using fdatasync()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AC_CHECK_HEADERS(limits.h stddef.h fcntl.h)
 AC_CHECK_FUNCS(memmove memset munmap strchr strtoul stroull strlcat fdatasync)
+AC_CHECK_DECLS(fdatasync, [], [], [#include <unistd.h>])
 AC_CHECK_LIB(pthread, pthread_mutex_init, ,
 	     AC_MSG_ERROR(*** A POSIX threads library is required, aborting ***))
 AC_CHECK_LIB(z, inflate, ,

--- a/src/prop_object.c
+++ b/src/prop_object.c
@@ -859,7 +859,7 @@ _prop_object_externalize_write_file(const char *fname, const char *xml,
 			goto bad;
 	}
 
-#ifdef HAVE_FDATASYNC
+#if defined(HAVE_FDATASYNC) && HAVE_DECL_FDATASYNC
 	if (fdatasync(fd) == -1)
 #else
 	if (fsync(fd) == -1)


### PR DESCRIPTION
## Introduction:

Hi, there are three problems I am trying to fix:

* In macos, fdatasync() is not a supported system call and should not be used.  It appears that fdatasync() is in the libs -- you can link with it, but it call is not in any header file -- this causes the compile error -- 'implicit declaration of function 'fdatasync' is invalid in C99'

```
 $ uname -a
Darwin macmini 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64

prop_object.c:863:6: error: implicit declaration of function 'fdatasync' is
      invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (fdatasync(fd) == -1)
            ^
1 error generated.

```

* I assume fsync() is good enough. Using the MacOS F_FULLFSYNC fcntl is not required for this patch.
* Be portable.  We still want to use fdatasync() on other platforms do support it.

## Proposed Fix:
Add a check for the presence of fdatasync() in the header files.  This requires a one line change to configure.ac:
`AC_CHECK_DECLS(fdatasync, [], [], [#include <unistd.h>])`

Only use fdatasync() if it is in the header files and you can link with it.
* On MacOS, we have these macros in config.h:
```
  #define HAVE_DECL_FDATASYNC 0
  #define HAVE_FDATASYNC 1
```
* On FreeBSD, we have these macros in config.h:
```
  #define HAVE_DECL_FDATASYNC 0
  /* #undef HAVE_FDATASYNC */
```
* On Linux, we have these macros in config.h:
```
  #define HAVE_DECL_FDATASYNC 1
  #define HAVE_FDATASYNC 1
```

I originally proposed this change to src/prop_object.c:

```
-#ifdef HAVE_FDATASYNC
+#if defined(HAVE_FDATASYNC) && \
+       defined(HAVE_DECL_FDATASYNC) && HAVE_DECL_FDATASYNC
        if (fdatasync(fd) == -1)
 #else
        if (fsync(fd) == -1)
```

But I am guessing this should work too:

```
-#ifdef HAVE_FDATASYNC
+#if defined(HAVE_FDATASYNC) && HAVE_DECL_FDATASYNC
        if (fdatasync(fd) == -1)
 #else
        if (fsync(fd) == -1)
```

## References:
* http://lists.apple.com/archives/darwin-dev/2009/Nov/msg00044.html
* http://blog.httrack.com/blog/2013/11/15/everything-you-always-wanted-to-know-about-fsync/
* https://code.google.com/p/leveldb/issues/detail?id=197
* https://code.google.com/p/portableproplib/issues/detail?id=4
